### PR TITLE
【改善】課題をやった人ごとに実行できるようにする

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "lesson1": "tsc && node dist/lesson_1/homework/homework.js",
     "lesson2": "tsc && node dist/lesson_2/homework/homework.js",
+    "run-homework": "node scripts/run-homework.js",
     "clean": "rm -rf dist"
   },
   "repository": {

--- a/scripts/run-homework.js
+++ b/scripts/run-homework.js
@@ -1,0 +1,41 @@
+// child_process モジュールから execSync をインポート
+const { execSync } = require("child_process");
+// path モジュールをインポート（OS問わず正しくパス結合するため）
+const path = require("path");
+
+// コマンドライン引数を取得（最初の2つはnodeとスクリプト名なので除外）
+const args = process.argv.slice(2);
+const [lessonArg, name] = args;
+
+// 引数が2つない場合は使い方を表示して終了
+if (!lessonArg || !name) {
+  console.error("使い方: npm run run-homework lesson2 karino");
+  process.exit(1);
+}
+
+// lessonの形式（例: lesson2）を正規表現で検証
+const lessonMatch = lessonArg.match(/^lesson(\d+)$/);
+if (!lessonMatch) {
+  console.error("レッスン名が正しくありません。例: lesson2");
+  process.exit(1);
+}
+
+// レッスン番号を抽出（例: "2"）
+const lessonNumber = lessonMatch[1];
+
+// フォルダ名を「lesson_2」の形で組み立て
+const lessonDir = `lesson_${lessonNumber}`;
+
+// 実行するJavaScriptファイルのパスを組み立て
+const jsPath = path.join("dist", lessonDir, "homework", name, "homework.js");
+
+try {
+  console.log("📦 TypeScriptをコンパイル中...");
+  execSync("tsc", { stdio: "inherit" });
+
+  console.log(`🚀 実行中: ${jsPath}`);
+  execSync(`node ${jsPath}`, { stdio: "inherit" });
+} catch (error) {
+  console.error("❌ 実行中にエラーが発生しました:", error.message);
+  process.exit(1);
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -27,6 +27,6 @@
     "skipDefaultLibCheck": true /* Skip type checking .d.ts files that are included with TypeScript. */,
     "skipLibCheck": true /* Skip type checking all .d.ts files. */
   },
-  "include": ["typescript-lessons/**/homework/*.ts"],
+  "include": ["typescript-lessons/**/homework/*/*.ts"],
   "exclude": ["node_modules", "dist"]
 }


### PR DESCRIPTION
 # 1. 概要
やった課題を受講者ごとにまとめられるようにする。

# 2. 変更内容
- homeworkディレクトリの直下に受講者ごとのディレクトリを作成
- 受講者のディレクトリにやった宿題を配置→受講者ごとにコンパイル、実行するように変更

# 3. 想定する運用
## 3.1. 準備
- ①各レッスンのディレクトリ`/workspaces/front-kaizen/typescript-lessons/lesson_*/homework`の直下に自分の受講者のディレクトリを作成する　（例）`lesson_1`の`karino`ディレクトリ
- ②自分の受講者のディレクトリにオリジナルの宿題ファイル`/workspaces/front-kaizen/typescript-lessons/lesson_*/homework/homework.ts`をコピーする

## 3.2. 宿題の対応/共有
- ①「準備-②」で自分の受講者ディレクトリにコピーした`homework.ts`で対応する
- ②このPRで追加したコマンド
- ③ブランチを切って、コミット＆リモートにプッシュ

# 4. 追加したコマンドの実行の使い方
`npm run run-homework [which_lesson] [trainee_name]`

- which_lesson:
  - レッスン名
  - 「_」（半角アンダースコア）は**無し**！　（例）`lesson1`
- trainee_name:
  - 受講者名
  - `homework`ディレクトリ直下のディレクトリ名と整合していること！　（例）`karino`